### PR TITLE
Add Swagger documentation for API routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ logs/
 
 # MongoDB data (if local)
 mongo_data/
+server/openapi.json

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,10 @@
+# Server
+
+## API Documentation
+
+Start the server (`npm run dev` or `npm start`) and open `http://localhost:PORT/docs`
+in your browser to view the live Swagger UI documentation.
+
+## Generating OpenAPI Spec
+
+Run `npm run docs` to output a static `openapi.json` file in the project root.

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "test": "echo \"no tests yet\" && exit 0",
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p .",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "docs": "tsx src/swagger.ts > openapi.json"
   },
   "keywords": [],
   "author": "",
@@ -34,6 +35,8 @@
     "@types/morgan": "^1.9.10",
     "@types/node": "^24.3.3",
     "tsx": "^4.19.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0"
   }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,8 @@ import cookieParser from "cookie-parser";
 import morgan from "morgan";
 import mongoose from "mongoose";
 import { fileURLToPath } from "url";
+import swaggerUi from "swagger-ui-express";
+import swaggerSpec from "./swagger.js";
 
 const app = express();
 app.use(morgan("dev"));
@@ -28,6 +30,7 @@ import taskRoutes from "./routes/task.js";
 app.use("/api/auth", authRoutes);
 app.use("/api/projects", projectRoutes);
 app.use("/api/tasks", taskRoutes);
+app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // --- Static client ---
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -7,6 +7,31 @@ import User from "../models/User.js";
 const router = Router();
 const JWT_SECRET = process.env.JWT_SECRET!;
 
+/**
+ * @openapi
+ * /api/auth/signup:
+ *   post:
+ *     summary: Register a new user
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - password
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: User created successfully
+ *       400:
+ *         description: Email already exists
+ */
 router.post("/signup", async (req, res) => {
   const { email, password } = req.body;
   const password_hash = await bcrypt.hash(password, 10);
@@ -19,6 +44,31 @@ router.post("/signup", async (req, res) => {
   }
 });
 
+/**
+ * @openapi
+ * /api/auth/login:
+ *   post:
+ *     summary: Authenticate a user
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - password
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Login successful
+ *       401:
+ *         description: Invalid credentials
+ */
 router.post("/login", async (req, res) => {
   const { email, password } = req.body;
   const user = await User.findOne({ email });
@@ -29,10 +79,32 @@ router.post("/login", async (req, res) => {
   res.cookie("token", token, { httpOnly: true, sameSite: "lax" }).json({ ok: true });
 });
 
+/**
+ * @openapi
+ * /api/auth/logout:
+ *   post:
+ *     summary: Log out the current user
+ *     responses:
+ *       200:
+ *         description: Logout successful
+ */
 router.post("/logout", (_req, res) => {
   res.clearCookie("token").json({ ok: true });
 });
 
+/**
+ * @openapi
+ * /api/auth/me:
+ *   get:
+ *     summary: Get the current user's profile
+ *     responses:
+ *       200:
+ *         description: User profile
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: User not found
+ */
 router.get("/me", requireAuth, async (req, res) => {
   const uid = (req as any).auth.uid as string;
   const user = await User.findById(uid).select("_id email createdAt");

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -19,6 +19,21 @@ const updateProjectSchema = z.object({
 router.use(requireAuth);
 
 // list my projects (optionally include archived)
+/**
+ * @openapi
+ * /api/projects:
+ *   get:
+ *     summary: List projects for the current user
+ *     parameters:
+ *       - in: query
+ *         name: includeArchived
+ *         schema:
+ *           type: boolean
+ *         description: Include archived projects
+ *     responses:
+ *       200:
+ *         description: Array of projects
+ */
 router.get("/", async (req, res) => {
   const uid = (req as any).auth.uid as string;
   const includeArchived = req.query.includeArchived === "true";
@@ -30,6 +45,28 @@ router.get("/", async (req, res) => {
 });
 
 // create
+/**
+ * @openapi
+ * /api/projects:
+ *   post:
+ *     summary: Create a project
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *             properties:
+ *               name:
+ *                 type: string
+ *               color:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Created project
+ */
 router.post("/", async (req, res) => {
   const uid = (req as any).auth.uid as string;
   const body = createProjectSchema.parse(req.body);
@@ -42,6 +79,29 @@ router.post("/", async (req, res) => {
 });
 
 // update
+/**
+ * @openapi
+ * /api/projects/{id}:
+ *   patch:
+ *     summary: Update a project
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *     responses:
+ *       200:
+ *         description: Updated project
+ *       404:
+ *         description: Not found
+ */
 router.patch("/:id", async (req, res) => {
   const uid = (req as any).auth.uid as string;
   const { id } = req.params;
@@ -57,6 +117,23 @@ router.patch("/:id", async (req, res) => {
 });
 
 // delete (hard delete for now; could soft-delete via archived=true)
+/**
+ * @openapi
+ * /api/projects/{id}:
+ *   delete:
+ *     summary: Delete a project
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Project deleted
+ *       404:
+ *         description: Not found
+ */
 router.delete("/:id", async (req, res) => {
   const uid = (req as any).auth.uid as string;
   const { id } = req.params;

--- a/server/src/routes/task.ts
+++ b/server/src/routes/task.ts
@@ -33,6 +33,44 @@ const listQuery = z.object({
 });
 
 // ---------- list ----------
+/**
+ * @openapi
+ * /api/tasks:
+ *   get:
+ *     summary: List tasks
+ *     parameters:
+ *       - in: query
+ *         name: projectId
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: completed
+ *         schema:
+ *           type: boolean
+ *       - in: query
+ *         name: filter
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: priority
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: q
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Paginated tasks
+ */
 router.get("/", async (req, res) => {
   const userId = (req as any).auth.uid as string;
   const { projectId, completed, filter, priority, q, page, pageSize } = listQuery.parse(req.query);
@@ -87,6 +125,37 @@ router.get("/", async (req, res) => {
 });
 
 // ---------- create ----------
+/**
+ * @openapi
+ * /api/tasks:
+ *   post:
+ *     summary: Create a task
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *             properties:
+ *               title:
+ *                 type: string
+ *               notes:
+ *                 type: string
+ *               projectId:
+ *                 type: string
+ *               priority:
+ *                 type: integer
+ *               dueDate:
+ *                 type: string
+ *                 format: date
+ *     responses:
+ *       201:
+ *         description: Created task
+ *       400:
+ *         description: Invalid projectId
+ */
 router.post("/", async (req, res) => {
   const userId = (req as any).auth.uid as string;
   const body = createTaskSchema.parse(req.body);
@@ -108,6 +177,25 @@ router.post("/", async (req, res) => {
 });
 
 // ---------- get single task ----------
+/**
+ * @openapi
+ * /api/tasks/{id}:
+ *   get:
+ *     summary: Get a task by id
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Task data
+ *       400:
+ *         description: Bad id
+ *       404:
+ *         description: Not found
+ */
 router.get("/:id", async (req, res) => {
   try {
     const userId = (req as any).auth.uid as string;
@@ -124,6 +212,31 @@ router.get("/:id", async (req, res) => {
 });
 
 // ---------- update ----------
+/**
+ * @openapi
+ * /api/tasks/{id}:
+ *   patch:
+ *     summary: Update a task
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *     responses:
+ *       200:
+ *         description: Updated task
+ *       400:
+ *         description: Bad id or invalid projectId
+ *       404:
+ *         description: Not found
+ */
 router.patch("/:id", async (req, res) => {
   const userId = (req as any).auth.uid as string;
   const { id } = req.params;
@@ -151,6 +264,23 @@ router.patch("/:id", async (req, res) => {
 });
 
 // ---------- complete / incomplete ----------
+/**
+ * @openapi
+ * /api/tasks/{id}/complete:
+ *   post:
+ *     summary: Mark a task as complete
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Completed task
+ *       404:
+ *         description: Not found
+ */
 router.post("/:id/complete", async (req, res) => {
   const userId = (req as any).auth.uid as string;
   const task = await Task.findOneAndUpdate(
@@ -162,6 +292,23 @@ router.post("/:id/complete", async (req, res) => {
   res.json(task);
 });
 
+/**
+ * @openapi
+ * /api/tasks/{id}/incomplete:
+ *   post:
+ *     summary: Mark a task as incomplete
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated task
+ *       404:
+ *         description: Not found
+ */
 router.post("/:id/incomplete", async (req, res) => {
   const userId = (req as any).auth.uid as string;
   const task = await Task.findOneAndUpdate(
@@ -174,6 +321,23 @@ router.post("/:id/incomplete", async (req, res) => {
 });
 
 // ---------- delete ----------
+/**
+ * @openapi
+ * /api/tasks/{id}:
+ *   delete:
+ *     summary: Delete a task
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Task deleted
+ *       404:
+ *         description: Not found
+ */
 router.delete("/:id", async (req, res) => {
   const userId = (req as any).auth.uid as string;
   const result = await Task.deleteOne({ _id: req.params.id, userId: new Types.ObjectId(userId) });

--- a/server/src/swagger.ts
+++ b/server/src/swagger.ts
@@ -1,0 +1,21 @@
+import swaggerJsdoc from "swagger-jsdoc";
+import path from "path";
+import { pathToFileURL } from "url";
+
+const options = {
+  definition: {
+    openapi: "3.0.0",
+    info: {
+      title: "Redoist API",
+      version: "1.0.0",
+    },
+  },
+  apis: [path.join(process.cwd(), "src/routes/**/*.ts")],
+};
+
+const swaggerSpec = swaggerJsdoc(options);
+export default swaggerSpec;
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(JSON.stringify(swaggerSpec, null, 2));
+}


### PR DESCRIPTION
## Summary
- integrate swagger-jsdoc and swagger-ui-express
- document auth, project, and task routes with OpenAPI annotations
- expose Swagger UI at `/docs`